### PR TITLE
[FIX] 휴가신청서 첨부파일 다운로드 URL 오류 FIX

### DIFF
--- a/src/main/resources/templates/doc/vacation_read.html
+++ b/src/main/resources/templates/doc/vacation_read.html
@@ -71,7 +71,7 @@
                         <th class="table-secondary font-weight-bold text-center">첨부 파일</th>
                         <td>
                             <th:block th:if="${docVacation.vacationFileOriginal != null}">
-                                <a th:href="@{/doc/download(fileName=${docVacation.vacationFileOriginal},fileUUID=${docVacation.vacationFileUUID})}">
+                                <a th:href="@{/api/doc/download(fileName=${docVacation.vacationFileOriginal},fileUUID=${docVacation.vacationFileUUID})}">
                                     [[${docVacation.vacationFileOriginal}]]
                                 </a>
                             </th:block>


### PR DESCRIPTION
- api 컨트롤러 분리하였으나, 기존 URL로 남아있었음